### PR TITLE
feat(nemo-customizer): accept Data as input

### DIFF
--- a/src/backend/base/langflow/components/nvidia/nemo_customizer.py
+++ b/src/backend/base/langflow/components/nvidia/nemo_customizer.py
@@ -1,10 +1,22 @@
-import httpx
-import json
-from langflow.custom import Component
-from langflow.io import MessageTextInput, Output, DropdownInput, IntInput, FloatInput, StrInput, DataInput
-from langflow.schema import Data, DataFrame
-import pandas as pd
 import asyncio
+import json
+from datetime import datetime
+from io import BytesIO
+
+import httpx
+import pandas as pd
+
+from langflow.custom import Component
+from langflow.io import (
+    DataInput,
+    DropdownInput,
+    FloatInput,
+    IntInput,
+    MessageTextInput,
+    Output,
+    StrInput,
+)
+from langflow.schema import Data
 
 class NVIDIANeMoCustomizerComponent(Component):
     display_name = "Customizer"
@@ -14,8 +26,8 @@ class NVIDIANeMoCustomizerComponent(Component):
     beta = True
 
     headers = {
-        'accept': 'application/json',
-        'Content-Type': 'application/json'
+        "accept": "application/json",
+        "Content-Type": "application/json"
     }
     chunk_number = 1
 
@@ -249,7 +261,7 @@ class NVIDIANeMoCustomizerComponent(Component):
         """
         try:
             # Inputs
-            user_dataset_name = getattr(self, 'dataset', None)
+            user_dataset_name = getattr(self, "dataset", None)
             dataset_name = await self.get_dataset_id(self.tenant_id, user_dataset_name)
             chunk_size = 10000  # Ensure chunk_size is an integer
             self.log(f"dataset_name : {dataset_name}", name="NVIDIANeMoCustomizerComponent")
@@ -269,7 +281,7 @@ class NVIDIANeMoCustomizerComponent(Component):
                     self.log(f"Skipping non-Data object in training data, but got: {data_obj}", name="NVIDIANeMoCustomizerComponent")
                     continue
 
-                # Extract only 'input' and 'completion' fields if present
+                # Extract only "input" and "completion" fields if present
                 filtered_data = {
                     "input": getattr(data_obj, "input", None),
                     "completion": getattr(data_obj, "completion", None)
@@ -311,12 +323,12 @@ class NVIDIANeMoCustomizerComponent(Component):
             # Serialize the chunk DataFrame to JSONL format
             json_content = chunk_df.to_json(orient="records", lines=True)
             file_name = f"{file_name_prefix}_chunk_{chunk_number}.jsonl"
-            file_in_memory = BytesIO(json_content.encode('utf-8'))
+            file_in_memory = BytesIO(json_content.encode("utf-8"))
 
             filepath = f"training/{file_name}"
             url = f"{base_url}/datasets/{dataset_id}/files/contents/{filepath}"
 
-            files = {'file': (file_name, file_in_memory, 'application/json')}
+            files = {"file": (file_name, file_in_memory, "application/json")}
 
             async with httpx.AsyncClient() as client:
                 response = await client.post(url, files=files)

--- a/src/backend/base/langflow/components/nvidia/nemo_customizer.py
+++ b/src/backend/base/langflow/components/nvidia/nemo_customizer.py
@@ -136,14 +136,16 @@ class NVIDIANeMoCustomizerComponent(Component):
 
                     self.log("Updated model_name dropdown options.")
             return build_config
+
         except httpx.HTTPStatusError as exc:
             error_msg = f"HTTP error {exc.response.status_code} on {models_url}"
             self.log(error_msg)
             raise ValueError(error_msg)
-        except Exception as exc:
+        except (httpx.RequestError, ValueError) as exc:
             error_msg = f"Error refreshing model names: {str(exc)}"
             self.log(error_msg)
             raise ValueError(error_msg)
+
 
     async def customize(self) -> dict:
         dataset_name = self.dataset
@@ -205,7 +207,7 @@ class NVIDIANeMoCustomizerComponent(Component):
             self.log(error_msg)
             raise ValueError(error_msg)
 
-        except Exception as exc:
+        except (httpx.RequestError, ValueError) as exc:
             error_msg = f"An unexpected error occurred on URL {customizations_url}: {str(exc)}"
             self.log(error_msg)
             raise ValueError(error_msg)

--- a/src/backend/base/langflow/components/nvidia/nemo_customizer.py
+++ b/src/backend/base/langflow/components/nvidia/nemo_customizer.py
@@ -164,18 +164,6 @@ class NVIDIANeMoCustomizerComponent(Component):
             },
             "sha": "main"
         }
-        data = {
-            "parent_model_id": self.model_name,
-            "dataset": dataset_name,
-            "hyperparameters": {
-                "training_type": self.training_type,
-                "epochs": int(self.epochs),
-                "batch_size": int(self.batch_size),
-                "learning_rate": float(self.learning_rate),
-                "adapter_dim": 16
-            },
-            "sha": "main"
-        }
         customizations_url = f"{self.base_url}/v2/customizations"
         try:
             formatted_data = json.dumps(data, indent=2)

--- a/src/backend/base/langflow/components/nvidia/nemo_customizer.py
+++ b/src/backend/base/langflow/components/nvidia/nemo_customizer.py
@@ -325,16 +325,14 @@ class NVIDIANeMoCustomizerComponent(Component):
             await asyncio.gather(*tasks)
 
             logger.info("All data has been processed and uploaded successfully.")
-            return dataset_name
+        return dataset_name
 
         except Exception:
             logger.exception("An error occurred")
             return "An error occurred"
 
     async def upload_chunk(self, chunk_df, chunk_number, file_name_prefix, dataset_id, base_url):
-        """
-        Asynchronously uploads a chunk of data to the REST API.
-        """
+        """Asynchronously uploads a chunk of data to the REST API."""
         try:
             # Serialize the chunk DataFrame to JSONL format
             json_content = chunk_df.to_json(orient="records", lines=True)
@@ -345,17 +343,18 @@ class NVIDIANeMoCustomizerComponent(Component):
             url = f"{base_url}/datasets/{dataset_id}/files/contents/{filepath}"
 
             files = {"file": (file_name, file_in_memory, "application/json")}
-
+            logger.info(f"Chunk %s uploaded successfully!", chunk_number)
             async with httpx.AsyncClient() as client:
                 response = await client.post(url, files=files)
 
-            if response.status_code == 200:
-                logger.info(f"Chunk {chunk_number} uploaded successfully!")
+            HTTP_STATUS_OK = 200
+            if response.status_code == HTTP_STATUS_OK:
+                logger.info(f"Chunk %s uploaded successfully!", chunk_number)
             else:
-                logger.warning(f"Failed to upload chunk {chunk_number}. Status code: {response.status_code}")
+                logger.warning(f"Failed to upload chunk %s. Status code: %s", chunk_number, response.status_code)
                 logger.warning(response.text)
 
         except Exception:
-            logger.exception(f"An error occurred while uploading chunk {chunk_number}")
+            logger.exception(f"An error occurred while uploading chunk %s", chunk_number)
         finally:
             file_in_memory.close()

--- a/src/backend/base/langflow/components/nvidia/nemo_customizer.py
+++ b/src/backend/base/langflow/components/nvidia/nemo_customizer.py
@@ -325,7 +325,7 @@ class NVIDIANeMoCustomizerComponent(Component):
             await asyncio.gather(*tasks)
 
             logger.info("All data has been processed and uploaded successfully.")
-        return dataset_name
+            return dataset_name
 
         except Exception:
             logger.exception("An error occurred")

--- a/src/backend/base/langflow/components/nvidia/nemo_customizer.py
+++ b/src/backend/base/langflow/components/nvidia/nemo_customizer.py
@@ -239,7 +239,7 @@ class NVIDIANeMoCustomizerComponent(Component):
                 return created_dataset.get("id")
 
         except httpx.HTTPStatusError as e:
-            print(f"Error processing datasets: {e}")
+            self.log(f"Error processing datasets: {e}")
             return None
 
     async def process_and_upload_dataset(self) -> str:

--- a/src/backend/base/langflow/components/nvidia/nemo_customizer.py
+++ b/src/backend/base/langflow/components/nvidia/nemo_customizer.py
@@ -135,8 +135,6 @@ class NVIDIANeMoCustomizerComponent(Component):
                     build_config["model_name"]["options"] = model_names
 
                     self.log("Updated model_name dropdown options.")
-            return build_config
-
         except httpx.HTTPStatusError as exc:
             error_msg = f"HTTP error {exc.response.status_code} on {models_url}"
             self.log(error_msg)
@@ -146,6 +144,8 @@ class NVIDIANeMoCustomizerComponent(Component):
             error_msg = f"Error refreshing model names: {exception_str}"
             self.log(error_msg)
             raise ValueError(error_msg) from exc
+
+        return build_config
 
     async def customize(self) -> dict:
         dataset_name = self.dataset
@@ -326,11 +326,11 @@ class NVIDIANeMoCustomizerComponent(Component):
             await asyncio.gather(*tasks)
 
             logger.info("All data has been processed and uploaded successfully.")
-            return dataset_name
-
         except Exception:
             logger.exception("An error occurred")
             return "An error occurred"
+
+        return dataset_name
 
     async def upload_chunk(self, chunk_df, chunk_number, file_name_prefix, dataset_id, base_url):
         """Asynchronously uploads a chunk of data to the REST API."""

--- a/src/backend/base/langflow/components/nvidia/nemo_customizer.py
+++ b/src/backend/base/langflow/components/nvidia/nemo_customizer.py
@@ -142,7 +142,8 @@ class NVIDIANeMoCustomizerComponent(Component):
             self.log(error_msg)
             raise ValueError(error_msg) from exc
         except (httpx.RequestError, ValueError) as exc:
-            error_msg = f"Error refreshing model names: {str(exc)}"
+            exception_str = str(exc)
+            error_msg = f"Error refreshing model names: {exception_str}"
             self.log(error_msg)
             raise ValueError(error_msg) from exc
 
@@ -197,18 +198,18 @@ class NVIDIANeMoCustomizerComponent(Component):
         except httpx.TimeoutException as exc:
             error_msg = f"Request to {customizations_url} timed out"
             self.log(error_msg)
-            raise ValueError(error_msg) from None
+            raise ValueError(error_msg) from exc
 
         except httpx.HTTPStatusError as exc:
             status_code = exc.response.status_code
             response_content = exc.response.text
-            error_msg = "HTTP error {} on URL: {}. Response content: {}".format(status_code, customizations_url,
-                                                                                response_content)
+            error_msg = f"HTTP error {status_code} on URL: {customizations_url}. Response content: {response_content}"
             self.log(error_msg)
             raise ValueError(error_msg) from exc
 
         except (httpx.RequestError, ValueError) as exc:
-            error_msg = f"An unexpected error occurred on URL {customizations_url}: {str(exc)}"
+            exception_str = str(exc)
+            error_msg = f"An unexpected error occurred on URL {customizations_url}: {exception_str}"
             self.log(error_msg)
             raise ValueError(error_msg) from exc
 
@@ -220,6 +221,7 @@ class NVIDIANeMoCustomizerComponent(Component):
 
     async def get_dataset_id(self, tenant_id: str, user_dataset_name: str) -> str:
         """Fetches the dataset ID by checking if a dataset with the constructed name exists.
+
         If the dataset does not exist, creates a new dataset and returns its ID.
 
         Args:

--- a/src/backend/base/langflow/components/nvidia/nemo_customizer.py
+++ b/src/backend/base/langflow/components/nvidia/nemo_customizer.py
@@ -118,12 +118,12 @@ class NVIDIANeMoCustomizerComponent(Component):
         Output(display_name="Job Result", name="data", method="customize"),
     ]
 
-    async def update_build_config(self, build_config, _field_value, field_name=None):
+    async def update_build_config(self, build_config, field_value, field_name=None):
         """Updates the component's configuration based on the selected option or refresh button."""
         models_url = f"{self.base_url}/v2/availableParentModels"
         try:
             if field_name == "model_name":
-                self.log(f"Refreshing model names from endpoint {models_url}")
+                self.log(f"Refreshing model names from endpoint {models_url}, value: {field_value}")
 
                 async with httpx.AsyncClient(timeout=5.0) as client:
                     response = await client.get(models_url, headers=self.headers)

--- a/src/backend/base/langflow/components/nvidia/nemo_customizer.py
+++ b/src/backend/base/langflow/components/nvidia/nemo_customizer.py
@@ -118,10 +118,8 @@ class NVIDIANeMoCustomizerComponent(Component):
         Output(display_name="Job Result", name="data", method="customize"),
     ]
 
-    async def update_build_config(self, build_config, field_value, field_name=None):
-        """
-        Updates the component's configuration based on the selected option or refresh button.
-        """
+    async def update_build_config(self, build_config, _field_value, field_name=None):
+        """Updates the component's configuration based on the selected option or refresh button."""
         models_url = f"{self.base_url}/v2/availableParentModels"
         try:
             if field_name == "model_name":

--- a/src/backend/base/langflow/components/nvidia/nemo_customizer.py
+++ b/src/backend/base/langflow/components/nvidia/nemo_customizer.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from io import BytesIO
 
 import httpx
@@ -217,7 +217,6 @@ class NVIDIANeMoCustomizerComponent(Component):
     def get_dataset_name(self, user_dataset_name=None):
         # Generate a default dataset name using the current date and time
         default_name = f"dataset-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}"
-
         # Use the user-provided name if available, otherwise the default
         return user_dataset_name if user_dataset_name else default_name
 

--- a/src/backend/base/langflow/components/nvidia/nemo_customizer.py
+++ b/src/backend/base/langflow/components/nvidia/nemo_customizer.py
@@ -1,8 +1,10 @@
 import httpx
 import json
 from langflow.custom import Component
-from langflow.io import MessageTextInput, Output, DropdownInput, IntInput, FloatInput, StrInput
-
+from langflow.io import MessageTextInput, Output, DropdownInput, IntInput, FloatInput, StrInput, DataInput
+from langflow.schema import Data, DataFrame
+import pandas as pd
+import asyncio
 
 class NVIDIANeMoCustomizerComponent(Component):
     display_name = "Customizer"
@@ -15,6 +17,7 @@ class NVIDIANeMoCustomizerComponent(Component):
         'accept': 'application/json',
         'Content-Type': 'application/json'
     }
+    chunk_number = 1
 
     inputs = [
         StrInput(
@@ -22,11 +25,28 @@ class NVIDIANeMoCustomizerComponent(Component):
             display_name="NVIDIA NeMo Customizer Base URL",
             info="The base URL of the NVIDIA NeMo Customizer API.",
         ),
+        StrInput(
+            name="datastore_base_url",
+            display_name="NVIDIA NeMo Datastore Base URL",
+            info="The nemo datastore base URL of the NVIDIA NeMo Datastore API.",
+            advanced=True
+        ),
+        StrInput(
+            name="tenant_id",
+            display_name="Tenant ID",
+            info="Tenant id for dataset creation, if not provided default value `tenant` is used.",
+            advanced=True
+        ),
         MessageTextInput(
             name="dataset",
             display_name="Dataset",
             info="Enter the dataset ID or name used to train the model",
             value="dataset-RWZGSkCGdeP35SDAxqTtvy"
+        ),
+        DataInput(
+            name="training_data",
+            display_name="Training Data",
+            is_list=True,
         ),
         DropdownInput(
             name="model_name",
@@ -112,9 +132,13 @@ class NVIDIANeMoCustomizerComponent(Component):
             raise ValueError(error_msg)
 
     async def customize(self) -> dict:
+        dataset_name = self.dataset
+        if self.training_data is not None:
+            dataset_name = await self.process_and_upload_dataset()
+        self.log(f"dataset_name: {dataset_name}")
         data = {
             "parent_model_id": self.model_name,
-            "dataset": self.dataset,
+            "dataset": dataset_name,
             "hyperparameters": {
                 "training_type": self.training_type,
                 "epochs": int(self.epochs),
@@ -124,9 +148,7 @@ class NVIDIANeMoCustomizerComponent(Component):
             },
             "sha": "main"
         }
-
         customizations_url = f"{self.base_url}/v2/customizations"
-
         try:
             formatted_data = json.dumps(data, indent=2)
 
@@ -161,3 +183,151 @@ class NVIDIANeMoCustomizerComponent(Component):
             error_msg = f"An unexpected error occurred on URL {customizations_url}: {str(exc)}"
             self.log(error_msg, name="NeMoCustomizerComponent")
             raise ValueError(error_msg)
+
+    def get_dataset_name(self, user_dataset_name=None):
+        # Generate a default dataset name using the current date and time
+        default_name = f"dataset-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+
+        # Use the user-provided name if available, otherwise the default
+        dataset_name = user_dataset_name if user_dataset_name else default_name
+
+        return dataset_name
+
+    async def get_dataset_id(self, tenant_id: str, user_dataset_name: str) -> str:
+        """
+        Fetches the dataset ID by checking if a dataset with the constructed name exists.
+        If the dataset does not exist, creates a new dataset and returns its ID.
+
+        Args:
+            tenant_id (str): The tenant ID.
+
+        Returns:
+            str: The dataset ID if found or created, or None if an error occurs.
+        """
+        appender = self.get_dataset_name(user_dataset_name)
+        dataset_name = f"{tenant_id}-{appender}"
+
+        url = f"{self.datastore_base_url}/v1/datasets"
+        page = 1
+
+        try:
+            async with httpx.AsyncClient() as client:
+                while True:
+                    response = await client.get(f"{url}?page_size=10&page={page}")
+                    if response.status_code == 422:
+                        self.log(f"No more pages to fetch, page: {page}")
+                        break;
+                    response.raise_for_status()
+
+                    datasets = response.json().get("datasets", [])
+                    for dataset in datasets:
+                        if dataset.get("name") == dataset_name:
+                            return dataset.get("id")
+                    if not datasets:
+                        break  # No more datasets to process
+
+                    page += 1
+
+                # If dataset not found, create it
+                create_payload = {
+                    "name": dataset_name,
+                    "description": f"{dataset_name} for {tenant_id}"
+                }
+                create_response = await client.post(url, json=create_payload)
+                create_response.raise_for_status()
+                created_dataset = create_response.json()
+                return created_dataset.get("id")
+
+        except httpx.HTTPStatusError as e:
+            print(f"Error processing datasets: {e}")
+            return None
+
+    async def process_and_upload_dataset(self) -> str:
+        """
+        Asynchronously processes and uploads the dataset to the API in chunks.
+        Returns the upload status.
+        """
+        try:
+            # Inputs
+            user_dataset_name = getattr(self, 'dataset', None)
+            dataset_name = await self.get_dataset_id(self.tenant_id, user_dataset_name)
+            chunk_size = 10000  # Ensure chunk_size is an integer
+            self.log(f"dataset_name : {dataset_name}")
+            if not dataset_name:
+                raise ValueError("dataset_name must be provided.")
+
+            # Endpoint configuration
+            url = f"{self.datastore_base_url}/v1"
+            tasks = []
+
+            chunk = []
+            file_name_appender = user_dataset_name if user_dataset_name else "dataset"
+            # Ensure DataFrame is iterable correctly
+            for data_obj in self.training_data or []:
+                # Check if the object is an instance of Data
+                if not isinstance(data_obj, Data):
+                    self.log(f"Skipping non-Data object in training data, but got: {data_obj}")
+                    continue
+
+                # Extract only 'input' and 'completion' fields if present
+                filtered_data = {
+                    "input": getattr(data_obj, "input", None),
+                    "completion": getattr(data_obj, "completion", None)
+                }
+
+                # Check if both fields are present
+                if filtered_data["input"] is not None and filtered_data["completion"] is not None:
+                    chunk.append(filtered_data)
+
+                # Process the chunk when it reaches the specified size
+                if len(chunk) == chunk_size:
+                    chunk_df = pd.DataFrame(chunk)
+                    task = self.upload_chunk(chunk_df, self.chunk_number, file_name_appender, dataset_name, url)
+                    tasks.append(task)
+                    chunk = []  # Reset the chunk
+                    self.chunk_number += 1
+
+            # Process the remaining rows in the last chunk
+            if chunk:
+                chunk_df = pd.DataFrame(chunk)
+                task = self.upload_chunk(chunk_df, self.chunk_number, file_name_appender, dataset_name, url)
+                tasks.append(task)
+
+            # Await all upload tasks
+            await asyncio.gather(*tasks)
+
+            logger.info("All data has been processed and uploaded successfully.")
+            return dataset_name
+
+        except Exception as e:
+            logger.error(f"An error occurred: {str(e)}")
+            return f"An error occurred: {str(e)}"
+
+    async def upload_chunk(self, chunk_df, chunk_number, file_name_prefix, dataset_id, base_url):
+        """
+        Asynchronously uploads a chunk of data to the REST API.
+        """
+        try:
+            # Serialize the chunk DataFrame to JSONL format
+            json_content = chunk_df.to_json(orient="records", lines=True)
+            file_name = f"{file_name_prefix}_chunk_{chunk_number}.jsonl"
+            file_in_memory = BytesIO(json_content.encode('utf-8'))
+
+            filepath = f"training/{file_name}"
+            url = f"{base_url}/datasets/{dataset_id}/files/contents/{filepath}"
+
+            files = {'file': (file_name, file_in_memory, 'application/json')}
+
+            async with httpx.AsyncClient() as client:
+                response = await client.post(url, files=files)
+
+            if response.status_code == 200:
+                logger.info(f"Chunk {chunk_number} uploaded successfully!")
+            else:
+                logger.warning(f"Failed to upload chunk {chunk_number}. Status code: {response.status_code}")
+                logger.warning(response.text)
+
+        except Exception as e:
+            logger.error(f"An error occurred while uploading chunk {chunk_number}: {str(e)}")
+        finally:
+            file_in_memory.close()

--- a/src/backend/base/langflow/components/nvidia/nemo_customizer.py
+++ b/src/backend/base/langflow/components/nvidia/nemo_customizer.py
@@ -142,10 +142,9 @@ class NVIDIANeMoCustomizerComponent(Component):
             self.log(error_msg)
             raise ValueError(error_msg) from exc
         except (httpx.RequestError, ValueError) as exc:
-            error_msg = "Error refreshing model names: {}".format(str(exc))
+            error_msg = f"Error refreshing model names: {str(exc)}"
             self.log(error_msg)
             raise ValueError(error_msg) from exc
-
 
     async def customize(self) -> dict:
         dataset_name = self.dataset
@@ -195,17 +194,16 @@ class NVIDIANeMoCustomizerComponent(Component):
                 result_dict["url"] = f"{customizations_url}/{id_value}"
                 return result_dict
 
-        except httpx.TimeoutException:
+        except httpx.TimeoutException as exc:
             error_msg = f"Request to {customizations_url} timed out"
             self.log(error_msg)
-            raise ValueError(error_msg)
-
+            raise ValueError(error_msg) from None
 
         except httpx.HTTPStatusError as exc:
             status_code = exc.response.status_code
             response_content = exc.response.text
-            error_msg = "HTTP error %s on URL: %s. Response content: %s" % (
-            status_code, customizations_url, response_content)
+            error_msg = "HTTP error {} on URL: {}. Response content: {}".format(status_code, customizations_url,
+                                                                                response_content)
             self.log(error_msg)
             raise ValueError(error_msg) from exc
 
@@ -222,7 +220,6 @@ class NVIDIANeMoCustomizerComponent(Component):
 
     async def get_dataset_id(self, tenant_id: str, user_dataset_name: str) -> str:
         """Fetches the dataset ID by checking if a dataset with the constructed name exists.
-
         If the dataset does not exist, creates a new dataset and returns its ID.
 
         Args:
@@ -232,7 +229,6 @@ class NVIDIANeMoCustomizerComponent(Component):
         Returns:
             str: The dataset ID if found or created, or None if an error occurs.
         """
-
         appender = self.get_dataset_name(user_dataset_name)
         tenant = tenant_id if tenant_id else "tenant"
         dataset_name = f"{tenant}-{appender}"
@@ -277,7 +273,6 @@ class NVIDIANeMoCustomizerComponent(Component):
 
         Returns the upload status.
         """
-
         try:
             # Inputs
             user_dataset_name = getattr(self, "dataset", None)


### PR DESCRIPTION
Added logic to accept langflow Data as input list. Data will be chunked and pushed as files into Nemo datastore and used for training. If training data is not mapped, the flow will look for the existing `dataset` input for Nemo datastore dataset id.